### PR TITLE
fix: wrong line number in report due to wrong filter

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -163,7 +163,7 @@ module.exports = function() {
 		var wordsFoundInLineNumber = [];
 		
 		try {
-			var lines = fs.readFileSync(inFile, 'utf-8').split('\n').filter(Boolean);
+			var lines = fs.readFileSync(inFile, 'utf-8').split('\n');
 			
 			var wordsToFindInLine = lineToFind.split(" ");
 			var wordsFoundInLine = [];


### PR DESCRIPTION
Hi, I found a bug that the report shows wrong line number, which due to the wrong filter in the  `findLineInFile()` of `/core/index.js`.

The source code file: (I renamed the extension because of upload limitation)
[class-aal-api.php.txt](https://github.com/user-attachments/files/21349501/class-aal-api.php.txt)

Before fixing:
```
<-- Checking for Injection Vulnerabilities -->
/Applications/XAMPP/xamppfiles/htdocs/thesis/aryo-activity-log.2.6.1/classes/class-aal-api.php File has a MySQL Injection Vulnerability (Found in line number: 16) 'query' function can be injected, Note: Unfinished command detected in this line.
/Applications/XAMPP/xamppfiles/htdocs/thesis/aryo-activity-log.2.6.1/classes/class-aal-api.php File has a MySQL Injection Vulnerability (Found in line number: 60) 'query' function can be injected
```

In the old report, it point out line number 16, 60 are problematic. However, the line 16 is:
```
15		if ( empty( $logs_lifespan ) )
16			return;
17		
```
And line 60 is:
```
59	* @return void
60	 */
61	public function erase_all_items() {
```

The expected line numbers are 18, 64. You can find that if you remove all blank lines in the source code, you'll get the correct result.

Therefore, I checked the source code of ASST, found that it will filter blank lines due to `.filter(Boolean)`. So, I think remove the filter here can solve this bug.

After fixing:
```
<-- Checking for Injection Vulnerabilities -->
/Applications/XAMPP/xamppfiles/htdocs/thesis/aryo-activity-log.2.6.1/classes/class-aal-api.php File has a MySQL Injection Vulnerability (Found in line number: 18) 'query' function can be injected, Note: Unfinished command detected in this line.
/Applications/XAMPP/xamppfiles/htdocs/thesis/aryo-activity-log.2.6.1/classes/class-aal-api.php File has a MySQL Injection Vulnerability (Found in line number: 64) 'query' function can be injected
```